### PR TITLE
 "watir-webdriver" replaced with "watir"

### DIFF
--- a/lib/watir-get-image-content.rb
+++ b/lib/watir-get-image-content.rb
@@ -1,2 +1,2 @@
-require "watir-webdriver"
+require "watir"
 require "watir-get-image-content/image"


### PR DESCRIPTION
 "watir-webdriver" is deprecated. Please, use require "watir"