### PR TITLE
Updated watir-webdriver dependency to watir

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Or install it yourself as:
 ## Usage
 
 ```ruby
-require 'watir-webdriver'
+require 'watir'
 require 'watir-get-image-content'
 browser = Watir::Browser.new
 browser.goto 'http://for_example.com/page_with_images'

--- a/lib/watir-get-image-content.rb
+++ b/lib/watir-get-image-content.rb
@@ -1,2 +1,2 @@
-require "watir-webdriver"
+require "watir"
 require "watir-get-image-content/image"

--- a/watir-get-image-content.gemspec
+++ b/watir-get-image-content.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "watir-webdriver"
+  spec.add_dependency "watir"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
watir-webdriver gem is now replaced by watir. We would like to use this gem in a cucumber project using watir.
Changes were simple. Replaced 'watir-webdriver' with 'watir'. Specs passed.